### PR TITLE
Use Anakotmai font on chart and lower data length on smaller screen

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -4,7 +4,11 @@
   import covtest from "./covtest.json"
   import Cards from "./Cards.svelte"
 
-  const records = covtest.result.records.slice(-30)
+  Chart.defaults.font.family = '"Anakotmai", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif'
+
+  const chartDataLength = window.innerWidth > 576 ? 30 : 10
+
+  const records = covtest.result.records.slice(-chartDataLength)
 
   const labels = records.map((record) => record.Date.split(" ")[0])
 
@@ -58,6 +62,9 @@
               type: "linear",
               display: true,
               position: "left",
+              afterFit: (scale) => {
+                scale.width = 58
+              },
             },
             y1: {
               type: "linear",


### PR DESCRIPTION
ลองปรับ default font family ของ Chart ให้เป็นแบบเดียวกับตัวหน้าเว็บครับ

และเช็คขนาดหน้าจอก่อน slice records เพื่อคุมขนาดข้อมูลที่แสดงบน Chart (จอใหญ่กว่า 576 แสดง 30 เหมือนเดิม แต่เล็กกว่านั้นแสดง 10)

อนึ่ง ตอนแก้ font เจอปัญหาเลขแกน y ล้นบางครั้ง (ไม่มั่นใจเหมือนกันว่าทำไม)
เลยปรับความกว้างส่วนที่แสดงตัวเลขแกน y ด้านซ้ายเอง (ทำให้มันคำนวณใหม่ไม่เป็นเลย fix ไว้ว่า scale.width = 58)
ตอนนี้ปรับความกว้างไว้พอดีเลขหลักหมื่น แต่คิดว่าถ้าเลขตรวจเริ่มแตะหลักแสนอาจต้องปรับความกว้างตรงนี้อีกที

![Screenshot 2021-07-14 020401](https://user-images.githubusercontent.com/15229977/125513147-49aa3e04-7a03-4850-aaec-a5a2329fe9eb.png)
